### PR TITLE
Initialize plot ranges from the defaults

### DIFF
--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -581,12 +581,12 @@ def month_stats_and_plots(start, opt, redo=False):
                                              'passlist.htm'), 'w')
                 passlist.write("<TABLE>\n")
                 passdates = []
-                temp_range = dict(aca_temp=dict(max=None,
-                                                min=None),
-                                  ccd_temp=dict(max=None,
-                                                min=None),
-                                  dtemp=dict(max=None,
-                                             min=None))
+                temp_range = dict(aca_temp=dict(max=ACA_TEMP_PLOT['ylim'][1],
+                                                min=ACA_TEMP_PLOT['ylim'][0]),
+                                  ccd_temp=dict(max=CCD_TEMP_PLOT['ylim'][1],
+                                                min=CCD_TEMP_PLOT['ylim'][0]),
+                                  dtemp=dict(max=DACVSDTEMP_PLOT['ylim'][1],
+                                             min=DACVSDTEMP_PLOT['ylim'][0]))
 
                 for pass_dir in months[month]:
                     match_date = re.search(


### PR DESCRIPTION
Initialize plot ranges from the defaults

There are so many other things that need fixing in here, but at least this should keep it from erroring out with:
```
    665                 plt.ylim(DACVSDTEMP_PLOT['ylim'])
    666                 plt.xlim(min(DACVSDTEMP_PLOT['xlim'][0],
--> 667                              -0.5 + temp_range['dtemp']['min']),
    668                          max(DACVSDTEMP_PLOT['xlim'][1],
    669                              +0.5 + temp_range['dtemp']['max']))

TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```
when it tries to make a plot for a month when there have not yet been any perigee passes.