### PR TITLE
Use config DAVCSDTEMP_PLOT xlim for dtemp default lims

### DIFF
--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -585,8 +585,8 @@ def month_stats_and_plots(start, opt, redo=False):
                                                 min=ACA_TEMP_PLOT['ylim'][0]),
                                   ccd_temp=dict(max=CCD_TEMP_PLOT['ylim'][1],
                                                 min=CCD_TEMP_PLOT['ylim'][0]),
-                                  dtemp=dict(max=DACVSDTEMP_PLOT['ylim'][1],
-                                             min=DACVSDTEMP_PLOT['ylim'][0]))
+                                  dtemp=dict(max=DACVSDTEMP_PLOT['xlim'][1],
+                                             min=DACVSDTEMP_PLOT['xlim'][0]))
 
                 for pass_dir in months[month]:
                     match_date = re.search(


### PR DESCRIPTION
Use config DAVCSDTEMP_PLOT xlim for dtemp default lims

This is all basically crap, but just swapping the code to use the intended-for-xlim axis limits as the xlim limits fixes the scale being off by ~500 units.

Closes #17 