### PR TITLE
Get ACA model from chandra_models repo via xija code

### DIFF
--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -758,7 +758,8 @@ def month_stats_and_plots(start, opt, redo=False):
                          max(CCD_TEMP_PLOT['ylim'][1],
                              temp_range['ccd_temp']['max'],
                              model_ccd_temp.comp['aacccdpt'].mvals.max()))
-                plt.ylabel(f'CCD Temp (C)\nchandra_models {model_version}')
+                plt.title(f'ACA model {model_version} vs. telemetry')
+                plt.ylabel(f'CCD Temp (C)')
                 plt.grid(True)
                 plt.savefig(os.path.join(month_web_dir, 'ccd_temp_all.png'))
                 plt.close(f)

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -31,6 +31,7 @@ from Ska.Matplotlib import plot_cxctime
 import xija
 from xija.get_model_spec import get_xija_model_spec
 
+
 # Colors for plots: red, green, blue, magenta, cyan, orange, purple... maybe
 PLOT_COLORS = ['#ff0000', '#00ff00', '#0000ff',
                '#ff00ff', '#00ffff', '#ff6600',


### PR DESCRIPTION
Get ACA model from chandra_models repo via xija code

No unit tests.

For functional tests I ran the code to a temporary web directory and it ran fine and grabbed the right version of the model (I stuck in the chandra_models version over on the Y axis label).
