### PR TITLE
Use chandra_models for planning limit

### DIFF
--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -30,6 +30,7 @@ from mica.archive import aca_hdr3
 from Ska.Matplotlib import plot_cxctime
 import xija
 from xija.get_model_spec import get_xija_model_spec
+import proseco.characteristics
 
 
 # Colors for plots: red, green, blue, magenta, cyan, orange, purple... maybe
@@ -52,7 +53,7 @@ TELEM_CHOMP_LIMITS = {'dac': {'max': 550},
 
 # If telem values exceed these limits send a warning
 # This is intended to be planning limit +1C
-TELEM_LIMITS = {'ccd_temp': {'max': -6.5 + 1}}
+TELEM_LIMITS = {'ccd_temp': {'max': proseco.characteristics.aca_t_ccd_planning_limit + 1}}
 
 # Plot ranges
 DAC_PLOT = {'ylim': (460, 515)}


### PR DESCRIPTION
## Description

Fetch the planning limit from the aca chandra_model via proseco characteristics.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This fixes the issue that the code would previously need manual update for each ACA planning limit increase.

## Interface impacts

No interface impact.

## Testing

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

### Functional tests
I just ran this using a local web and test directory and see the expected outputs, including a warning based on the (current and correct) ACA planning limit.
```
In [1]: run perigee_health_plots/pass_plots.py --data_dir data --web_dir web
Limit Exceeded, ccd_temp of  -3.94 is >  -4.20 
 at http://cxc.harvard.edu/mta/ASPECT/perigee_health_plots/PASS_DATA/2022/2022:089:00:11:17.270
```
