### PR TITLE
Include all hdr3 8x8 data in plots

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: "3.10"
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 . --count --ignore=E402,W503,W504,F541 --max-line-length=100 --show-source --statistics
+        flake8 . --exclude=docs --count --ignore=E402,W503,W504,F541 --max-line-length=100 --show-source --statistics

--- a/perigee_health_plots/month_index_template.html
+++ b/perigee_health_plots/month_index_template.html
@@ -33,12 +33,9 @@
 <BR /> 
 
 <P>Summary plots of ACA housing temperature, CCD temperature, and DAC
-control level. Data is only available during perigee passes, so each
-point on these summary plots represents the mean of the aforementioned
-indicators during a perigee pass. Plots for single passes are
-available from the links below.
+control level.
 
-<P>Plots for each perigee pass summarized above are available from the links below. 
+<P>Plots for each orbit summarized above are available from the links below.
 
 <!--#include virtual="passlist.htm" -->
 

--- a/perigee_health_plots/pass_index_template.html
+++ b/perigee_health_plots/pass_index_template.html
@@ -28,9 +28,7 @@
 <!--#include virtual="obslist.htm" -->
 
 <P>Plots of ACA housing temperature, CCD temperature, and DAC
-control level. Data is only available during perigee passes or other 8x8 ERs.
-Datestart and datestop correspond to the time range when 8x8 
-ACA telemetry is available for all required slots.
+control level.
 
 
 

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -58,9 +58,9 @@ TELEM_LIMITS = {'ccd_temp': {'max': proseco.characteristics.aca_t_ccd_planning_l
 # Plot ranges
 DAC_PLOT = {'ylim': (460, 515)}
 DACVSDTEMP_PLOT = {'ylim': (460, 515),
-                   'xlim': (37, 40)}
-ACA_TEMP_PLOT = {'ylim': (8, 32)}
-CCD_TEMP_PLOT = {'ylim': (-15, -5)}
+                   'xlim': (37, 45)}
+ACA_TEMP_PLOT = {'ylim': (20, 40)}
+CCD_TEMP_PLOT = {'ylim': (-15, -3)}
 
 
 log = logging.getLogger()

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -239,8 +239,8 @@ def orbit_parse(pass_dir, min_samples=5, time_interval=20):
                     'ccd_temp': hdr3['ccd_temp']}
 
     if not len(parsed_telem['ccd_temp'].vals):
-        raise MissingDataError("No HDR3 data for pass {}".format(
-                pass_times[0]['obsid_datestart']))
+        raise MissingDataError(
+            f"No HDR3 data for pass {pass_times[0]['obsid_datestart']}")
     return parsed_telem
 
 

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -724,17 +724,19 @@ def month_stats_and_plots(start, opt, redo=False):
                     DateTime(passdates[0]).secs - 86400,
                     model_end_time,
                     np.mean(ccd_temps[0:10]))
-                plot_cxctime(ccd_times, ccd_temps, 'k.')
+                plot_cxctime(ccd_times, ccd_temps, 'b.', markersize=2.5,
+                             label='telem')
                 plot_cxctime(model_ccd_temp.times,
                              model_ccd_temp.comp['aacccdpt'].mvals,
-                             'b.', markersize=2)
+                             'r', label='model')
                 plt.ylim(min(CCD_TEMP_PLOT['ylim'][0],
                              temp_range['ccd_temp']['min'] - 1,
                              model_ccd_temp.comp['aacccdpt'].mvals.min() - 1),
                          max(CCD_TEMP_PLOT['ylim'][1],
                              temp_range['ccd_temp']['max'] + 1,
                              model_ccd_temp.comp['aacccdpt'].mvals.max() + 1))
-                plt.title(f'ACA model {model_version} vs. telemetry')
+                plt.title(f'ACA model {model_version} and telemetry')
+                plt.legend()
                 plt.ylabel('CCD Temp (C)')
                 plt.grid(True)
                 plt.savefig(os.path.join(month_web_dir, 'ccd_temp_all.png'))

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -11,13 +11,7 @@ from itertools import cycle
 from jinja2 import Template
 import json
 import matplotlib
-
-# Matplotlib setup
-# Use Agg backend for command-line (non-interactive) operation
-if __name__ == '__main__':
-    matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-plt.rcParams['lines.markeredgewidth'] = 0
 from astropy.table import Table
 
 from kadi import events
@@ -31,6 +25,9 @@ from Ska.Matplotlib import plot_cxctime
 import xija
 from xija.get_model_spec import get_xija_model_spec
 import proseco.characteristics
+
+
+plt.rcParams['lines.markeredgewidth'] = 0
 
 
 # Colors for plots: red, green, blue, magenta, cyan, orange, purple... maybe
@@ -69,7 +66,7 @@ log.setLevel(logging.DEBUG)
 # emails...
 smtp_handler = SMTPHandler('localhost',
                            'aca@head.cfa.harvard.edu',
-                           'aca@cfa.harvard.edu',
+                           'jconnelly@cfa.harvard.edu',
                            'perigee health mon')
 
 smtp_handler.setLevel(logging.WARN)
@@ -135,9 +132,9 @@ def aca_ccd_model(tstart, tstop, init_temp):
 
 
 def retrieve_telem(start='2009:100:00:00:00.000',
-                           stop=None,
-                           pass_data_dir='.',
-                           redo=False):
+                   stop=None,
+                   pass_data_dir='.',
+                   redo=False):
     """
     Retrieve perigee pass and other 8x8 image telemetry.
 
@@ -741,7 +738,7 @@ def month_stats_and_plots(start, opt, redo=False):
                              temp_range['ccd_temp']['max'],
                              model_ccd_temp.comp['aacccdpt'].mvals.max()))
                 plt.title(f'ACA model {model_version} vs. telemetry')
-                plt.ylabel(f'CCD Temp (C)')
+                plt.ylabel('CCD Temp (C)')
                 plt.grid(True)
                 plt.savefig(os.path.join(month_web_dir, 'ccd_temp_all.png'))
                 plt.close(f)
@@ -784,6 +781,8 @@ def month_stats_and_plots(start, opt, redo=False):
 
 
 def main():
+
+    matplotlib.use("Agg")
 
     (opt, args) = get_options()
     ch = logging.StreamHandler()

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -45,7 +45,7 @@ MIN_SAMPLES = 5
 TELEM_CHOMP_LIMITS = {'dac': {'max': 550},
                       'ccd_temp': {'min': -35,
                                    'max': 50},
-                      'aca_temp': {'max': 50,
+                      'aca_temp': {'max': 60,
                                    'min': 5}}
 
 # If telem values exceed these limits send a warning
@@ -56,8 +56,8 @@ TELEM_LIMITS = {'ccd_temp': {'max': proseco.characteristics.aca_t_ccd_planning_l
 DAC_PLOT = {'ylim': (460, 515)}
 DACVSDTEMP_PLOT = {'ylim': (460, 515),
                    'xlim': (37, 45)}
-ACA_TEMP_PLOT = {'ylim': (20, 40)}
-CCD_TEMP_PLOT = {'ylim': (-15, -3)}
+ACA_TEMP_PLOT = {'ylim': (9, 40)}
+CCD_TEMP_PLOT = {'ylim': (-16, -3)}
 
 
 log = logging.getLogger()
@@ -66,7 +66,7 @@ log.setLevel(logging.DEBUG)
 # emails...
 smtp_handler = SMTPHandler('localhost',
                            'aca@head.cfa.harvard.edu',
-                           'jconnelly@cfa.harvard.edu',
+                           'aca@cfa.harvard.edu',
                            'perigee health mon')
 
 smtp_handler.setLevel(logging.WARN)

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -239,11 +239,8 @@ def orbit_parse(pass_dir, min_samples=5, time_interval=20):
                     'ccd_temp': hdr3['ccd_temp']}
 
     if not len(parsed_telem['ccd_temp'].vals):
-        if DateTime(maxtime) - DateTime(mintime) < 1.5:
-            raise MissingDataError("No HDR3 data for pass {}".format(
+        raise MissingDataError("No HDR3 data for pass {}".format(
                 pass_times[0]['obsid_datestart']))
-        else:
-            raise ValueError("Long pass with no HDR3")
     return parsed_telem
 
 

--- a/perigee_health_plots/pass_plots.py
+++ b/perigee_health_plots/pass_plots.py
@@ -729,11 +729,11 @@ def month_stats_and_plots(start, opt, redo=False):
                              model_ccd_temp.comp['aacccdpt'].mvals,
                              'b.', markersize=2)
                 plt.ylim(min(CCD_TEMP_PLOT['ylim'][0],
-                             temp_range['ccd_temp']['min'],
-                             model_ccd_temp.comp['aacccdpt'].mvals.min()),
+                             temp_range['ccd_temp']['min'] - 1,
+                             model_ccd_temp.comp['aacccdpt'].mvals.min() - 1),
                          max(CCD_TEMP_PLOT['ylim'][1],
-                             temp_range['ccd_temp']['max'],
-                             model_ccd_temp.comp['aacccdpt'].mvals.max()))
+                             temp_range['ccd_temp']['max'] + 1,
+                             model_ccd_temp.comp['aacccdpt'].mvals.max() + 1))
                 plt.title(f'ACA model {model_version} vs. telemetry')
                 plt.ylabel('CCD Temp (C)')
                 plt.grid(True)


### PR DESCRIPTION
## Description
Include all hdr3/8x8 data in plots

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This PR breaks the data into orbits instead of by contiguous ERs (perigee passes).
The project itself might need more renaming and reoganizing.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
python -m perigee_health_plots.pass_plots --start_time 2023:250 --web_dir web --data_dir data --web_server https://icxc.cfa.harvard.edu/ --url_dir /aspect/test_review_outputs/perigee_health_plots-pr23/web/
```
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/perigee_health_plots-pr23/web/
